### PR TITLE
Feature/filter rewards by categories

### DIFF
--- a/app/controllers/employees/rewards_controller.rb
+++ b/app/controllers/employees/rewards_controller.rb
@@ -1,8 +1,10 @@
 module Employees
   class RewardsController < EmployeesController
     def index
-      @rewards = Reward.page params[:page]
-      render :index, locals: { rewards: @rewards }
+      @rewards = RewardsQuery.new.call(params).page params[:page]
+      categories = Category.all
+      valid_category = categories.map(&:title).include?(params[:category])
+      render :index, locals: { rewards: @rewards, categories: categories, valid_category: valid_category }
     end
 
     def show

--- a/app/queries/rewards_query.rb
+++ b/app/queries/rewards_query.rb
@@ -1,0 +1,21 @@
+class RewardsQuery
+  attr_reader :initial_scope
+
+  def initialize(initial_scope = Reward.all)
+    @initial_scope = initial_scope
+  end
+
+  def call(params)
+    filter_by_category(params[:category])
+  end
+
+  private
+
+  def filter_by_category(filter = nil)
+    if Category.all.exists?(title: filter)
+      initial_scope.joins(:categories).where('categories.title': filter)
+    else
+      initial_scope
+    end
+  end
+end

--- a/app/views/employees/rewards/index.html.erb
+++ b/app/views/employees/rewards/index.html.erb
@@ -1,26 +1,49 @@
-<div class='title'>Reward</div>
-<table>
-  <thead>
-    <tr>
-      <th>Title</th>
-      <th>Price</th>
-      <th colspan="1"></th>
-    </tr>
-  </thead>
-  <tbody>
-    <% rewards.each do |reward| %>
+<div class='title'>Rewards <%="| #{params[:category]}" if valid_category%></div>
+<div class="dropdown is-hoverable is-pulled-right">
+  <div class="dropdown-trigger">
+    <button class="button" aria-haspopup="true" aria-controls="dropdown-menu">
+      <span>Filter</span>
+      <span class="icon is-small">
+        <i class="fas fa-angle-down" aria-hidden="true"></i>
+      </span>
+    </button>
+  </div>
+  <div class="dropdown-menu" id="dropdown-menu" role="menu">
+    <div class="dropdown-content">
+      <%= link_to "All", rewards_path, class: class_names('dropdown-item', { 'is-active': !valid_category }) %>
+      <% categories.each do |cat|%>
+        <%= link_to cat.title, rewards_url(category: cat.title), class: class_names('dropdown-item', { 'is-active': params[:category]==cat.title })%>
+        <% end %>
+    </div>
+  </div>
+</div>
+<% if rewards.empty? %>
+  There's no rewards in this category at the moment.
+<% else %>
+  <table>
+    <thead>
       <tr>
-        <td><%= reward.title %></td>
-        <td><%= reward.price %></td>
-        <td>
-        <% if current_employee.points >= reward.price%>
-        <%= link_to "Buy", new_order_path(reward) %>
-        <%end%>
-        </td>
-        <td><%= link_to "Show", reward_path(reward) %></td>
+        <th>Title</th>
+        <th>Price</th>
+        <th colspan="2"></th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      
+      <% rewards.each do |reward| %>
+        <tr>
+          <td><%= reward.title %></td>
+          <td><%= reward.price %></td>
+          <td>
+          <% if current_employee.points >= reward.price%>
+          <%= link_to "Buy", new_order_path(reward) %>
+          <%end%>
+          </td>
+          <td><%= link_to "Show", reward_path(reward) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>
 <br>
 <%= paginate @rewards, window: 1, outer_window: 1%>

--- a/app/views/employees/rewards/index.html.erb
+++ b/app/views/employees/rewards/index.html.erb
@@ -18,7 +18,7 @@
   </div>
 </div>
 <% if rewards.empty? %>
-  There's no rewards in this category at the moment.
+  There are no rewards in this category at the moment.
 <% else %>
   <table>
     <thead>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
   scope module: 'employees' do
     resources :kudos
     resources :rewards, only: %i[index show]  do
-      get 'page/:page', action: :index, on: :collection
+      get '(category/:category)(/page/:page)', action: :index, on: :collection, as: ''
     end
     resources :orders, only: %i[new create]
     resources :employees do

--- a/spec/system/employees/reward_handling_spec.rb
+++ b/spec/system/employees/reward_handling_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Rewards handling allows' do
     click_link category.title
     expect(page).to have_content "Rewards | #{category.title}"
     expect(page).to have_no_content reward.title
-    expect(page).to have_content "There are no rewards in this category at the moment."
+    expect(page).to have_content 'There are no rewards in this category at the moment.'
   end
 
   context 'when there are more than 3 rewards' do

--- a/spec/system/employees/reward_handling_spec.rb
+++ b/spec/system/employees/reward_handling_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Rewards handling allows' do
   let!(:employee) { create(:employee) }
   let!(:reward) { create(:reward) }
+  let!(:category) { create(:category) }
 
   before do
     sign_in employee
@@ -22,6 +23,21 @@ RSpec.describe 'Rewards handling allows' do
     expect(page).to have_content reward.title
     expect(page).to have_content reward.description
     expect(page).to have_content reward.price
+  end
+
+  it 'Employee to filter rewards by category' do
+    visit rewards_path
+
+    expect(page).to have_content reward.title
+    expect(page).to have_link reward.categories[0].title
+    expect(page).to have_link category.title
+    click_link reward.categories[0].title
+    expect(page).to have_content reward.title
+    expect(page).to have_content "Rewards | #{reward.categories[0].title}"
+    click_link category.title
+    expect(page).to have_content "Rewards | #{category.title}"
+    expect(page).to have_no_content reward.title
+    expect(page).to have_content "There's no rewards in this category at the moment."
   end
 
   context 'when there are more than 3 rewards' do

--- a/spec/system/employees/reward_handling_spec.rb
+++ b/spec/system/employees/reward_handling_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Rewards handling allows' do
     click_link category.title
     expect(page).to have_content "Rewards | #{category.title}"
     expect(page).to have_no_content reward.title
-    expect(page).to have_content "There's no rewards in this category at the moment."
+    expect(page).to have_content "There are no rewards in this category at the moment."
   end
 
   context 'when there are more than 3 rewards' do


### PR DESCRIPTION
Implement reward filtering based on categories for employees

In this PR I implemented filtering with query object for rewards based on categories. 
To allow user (and SEO) friendly URLs I also changed routes and decided to filter based on category title rather than id.