### PR TITLE
Refactor/changed the way reward is stored in order

### DIFF
--- a/app/controllers/employees/orders_controller.rb
+++ b/app/controllers/employees/orders_controller.rb
@@ -10,7 +10,7 @@ module Employees
     end
 
     def show
-      reward = order.reward.to_json
+      reward = order.reward
       render :show, locals: { order: order, reward: reward }
     end
 
@@ -23,13 +23,12 @@ module Employees
 
     def create
       @order = Order.new(order_params)
-      ordered_reward = Reward.from_json(order.reward)
-      reward = Reward.find_by(id: ordered_reward.id)
+      order.reward_price = order.reward.price
       order.buyer = current_employee
-      if order.buyer.points < ordered_reward.price
+      if order.buyer.points < order.reward_price
         redirect_to rewards_path, alert: 'Not enough points'
       elsif order.save
-        order.buyer.decrement(:points, ordered_reward.price).save
+        order.buyer.decrement(:points, order.reward_price).save
         redirect_to rewards_path, notice: 'Order was successfully created.'
       else
         render :new, locals: { order: order, reward: reward }
@@ -43,7 +42,7 @@ module Employees
     end
 
     def order_params
-      params.require(:order).permit(:reward)
+      params.require(:order).permit(:reward_id)
     end
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,6 +1,6 @@
 class Order < ApplicationRecord
   belongs_to :buyer, class_name: 'Employee'
-  serialize :reward, JSON
+  belongs_to :reward, class_name: 'Reward'
   enum status: { awaiting_delivery: 0, delivered: 1 }
   scope :ordered_by_status, ->(ordering_method = 'asc') { order(status: ordering_method) }
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,6 +1,6 @@
 class Order < ApplicationRecord
   belongs_to :buyer, class_name: 'Employee'
-  belongs_to :reward, class_name: 'Reward'
+  belongs_to :reward
   enum status: { awaiting_delivery: 0, delivered: 1 }
   scope :ordered_by_status, ->(ordering_method = 'asc') { order(status: ordering_method) }
 end

--- a/app/models/reward.rb
+++ b/app/models/reward.rb
@@ -8,11 +8,4 @@ class Reward < ApplicationRecord
   validates :price, numericality: { greater_than_or_equal_to: 1 }
   validates :categories, presence: true
   validates :picture, content_type: ['image/png', 'image/jpg']
-
-  def self.from_json(reward_json)
-    reward_from_json = JSON.parse(reward_json)
-    reward = Reward.new
-    reward.attribute_names.each { |attribute| reward[attribute] = reward_from_json[attribute] }
-    reward
-  end
 end

--- a/app/views/admins/orders/_index.html.erb
+++ b/app/views/admins/orders/_index.html.erb
@@ -11,7 +11,7 @@
   </thead>
   <tbody>
     <% orders.each do |order| %>
-    <% reward = Reward.from_json(order.reward)%>
+      <%reward = order.reward%>
       <tr>
         <td><%= order.id %></td>
         <td><%= reward.title %></td>

--- a/app/views/admins/orders/_index.html.erb
+++ b/app/views/admins/orders/_index.html.erb
@@ -11,7 +11,7 @@
   </thead>
   <tbody>
     <% orders.each do |order| %>
-      <%reward = order.reward%>
+      <% reward = order.reward %>
       <tr>
         <td><%= order.id %></td>
         <td><%= reward.title %></td>

--- a/app/views/employees/orders/_form.html.erb
+++ b/app/views/employees/orders/_form.html.erb
@@ -23,8 +23,7 @@
     </div>
   <div class="field">
     <div class='control'>
-      <%= form.hidden_field :reward, value: order.reward.to_json, class:'input', readonly: true%>
-
+      <%= form.hidden_field :reward_id, value: order.reward.id, class:'input', readonly: true%>
     </div>
   </div>
 

--- a/app/views/employees/orders/index.html.erb
+++ b/app/views/employees/orders/index.html.erb
@@ -29,7 +29,7 @@
   </thead>
   <tbody>
     <% orders.each do |order| %>
-    <% reward = order.reward%>
+    <% reward = order.reward %>
       <tr>
         <td><%= order.id %></td>
         <td><%= reward.title %></td>

--- a/app/views/employees/orders/index.html.erb
+++ b/app/views/employees/orders/index.html.erb
@@ -29,7 +29,7 @@
   </thead>
   <tbody>
     <% orders.each do |order| %>
-    <% reward = Reward.from_json(order.reward)%>
+    <% reward = order.reward%>
       <tr>
         <td><%= order.id %></td>
         <td><%= reward.title %></td>

--- a/app/views/notifications_mailer/notify_of_delivery.html.erb
+++ b/app/views/notifications_mailer/notify_of_delivery.html.erb
@@ -3,7 +3,7 @@
       Your order has been delivered.
     </p>
 
-    <% reward = Reward.from_json(@order.reward)%>
+    <% reward = @order.reward%>
     <div class='card-header-title'>
       Order nr. <%= @order.id %>
     </div>

--- a/app/views/notifications_mailer/notify_of_delivery.html.erb
+++ b/app/views/notifications_mailer/notify_of_delivery.html.erb
@@ -3,7 +3,7 @@
       Your order has been delivered.
     </p>
 
-    <% reward = @order.reward%>
+    <% reward = @order.reward %>
     <div class='card-header-title'>
       Order nr. <%= @order.id %>
     </div>

--- a/db/migrate/20220824114023_add_reward_price_to_orders.rb
+++ b/db/migrate/20220824114023_add_reward_price_to_orders.rb
@@ -1,0 +1,7 @@
+class AddRewardPriceToOrders < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :orders, :reward, :string
+    add_column :orders, :reward_price, :decimal
+    add_reference :orders, :reward, null: false, foreign_key: { to_table: :rewards}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_17_102653) do
+ActiveRecord::Schema.define(version: 2022_08_24_114023) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -104,12 +104,14 @@ ActiveRecord::Schema.define(version: 2022_08_17_102653) do
   end
 
   create_table "orders", force: :cascade do |t|
-    t.text "reward", null: false
     t.bigint "buyer_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "status", default: 0, null: false
+    t.decimal "reward_price"
+    t.bigint "reward_id", null: false
     t.index ["buyer_id"], name: "index_orders_on_buyer_id"
+    t.index ["reward_id"], name: "index_orders_on_reward_id"
     t.index ["status"], name: "index_orders_on_status"
   end
 
@@ -127,4 +129,5 @@ ActiveRecord::Schema.define(version: 2022_08_17_102653) do
   add_foreign_key "kudos", "employees", column: "giver_id"
   add_foreign_key "kudos", "employees", column: "receiver_id"
   add_foreign_key "orders", "employees", column: "buyer_id"
+  add_foreign_key "orders", "rewards"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -54,6 +54,6 @@ puts 'Creating orders'
   print '.'
   employee=Employee.find_by(email: "employee#{i}@test.com")
   Order.create(buyer: employee,
-              reward: Reward.all.sample.to_json)
+              reward: Reward.all.sample)
 end
 puts '✅'

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Notifications', type: :mailer do
   describe '- delivery' do
     let!(:employee) { create(:employee, points: 10) }
     let!(:reward) { create(:reward, price: 2) }
-    let!(:order) { create(:order, buyer: employee, reward: reward.to_json) }
+    let!(:order) { create(:order, buyer: employee, reward: reward) }
     let(:mail) { NotificationsMailer.with(employee: employee, order: order).notify_of_delivery }
 
     it 'renders the headers' do

--- a/spec/system/admins/order_handling_spec.rb
+++ b/spec/system/admins/order_handling_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Orders handling allows' do
   let!(:admin) { create(:admin) }
   let!(:employee) { create(:employee, points: 10) }
   let!(:reward) { create(:reward, price: 2) }
-  let!(:order) { create(:order, buyer: employee, reward: reward.to_json) }
+  let!(:order) { create(:order, buyer: employee, reward: reward) }
 
   before do
     sign_in admin

--- a/spec/system/admins/reward_handling_spec.rb
+++ b/spec/system/admins/reward_handling_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Rewards handling allows' do
     fill_in 'reward_price', with: 3.5
     click_on 'Create Reward'
     expect(page).to have_no_content 'Price must be greater than or equal to 1'
-    select category.title, from: 'category_ids'
+    select category.title, from: 'category_ids', match: :smart
     click_on 'Create Reward'
 
     expect(page).to have_content 'new test title'

--- a/spec/system/employees/order_handling_spec.rb
+++ b/spec/system/employees/order_handling_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 RSpec.describe 'Orders handling allows' do
   let!(:employee) { create(:employee, points: 10) }
   let!(:reward) { create(:reward, price: 2) }
-  let!(:order) { create(:order, buyer: employee, reward: reward.to_json) }
-  let!(:delivered_order) { create(:order, buyer: employee, reward: reward.to_json, status: :delivered) }
+  let!(:order) { create(:order, buyer: employee, reward: reward) }
+  let!(:delivered_order) { create(:order, buyer: employee, reward: reward, status: :delivered) }
 
   before do
     sign_in employee


### PR DESCRIPTION
Change the way orders store rewards so it's easier to implement csv export

I implemented associtiotion to reward and added new field for storing historic price of reward instead of previous approach of serializing whole reward. It should allow for easier handling orders in CSV files.