### PR TITLE
Refactor/use hash for result from service object

### DIFF
--- a/app/controllers/admins/rewards_controller.rb
+++ b/app/controllers/admins/rewards_controller.rb
@@ -31,7 +31,7 @@ module Admins
       rewards_file = params[:reward_file].open
       result = RewardImporter.call(rewards_file)
       if result.success?
-        redirect_to admins_rewards_path, notice: "Successfuly imported #{result.value!(:count)}"
+        redirect_to admins_rewards_path, notice: "Successfuly imported #{result.value!(:count)} rewards."
       else
         flash.now[:alert] = "Error occured during importing.
                              #{result.failure[:error]} in row: #{result.failure[:row]}

--- a/app/controllers/admins/rewards_controller.rb
+++ b/app/controllers/admins/rewards_controller.rb
@@ -29,22 +29,14 @@ module Admins
 
     def import
       rewards_file = params[:reward_file].open
-      rewards = rewards_hash(CSV.parse(rewards_file.read, col_sep: ','))
-      if rewards.pluck(:title).uniq.length != rewards.length
-        redirect_to import_admins_rewards_path, alert: 'There is more than one entry per reward!'
-        return
-      end
-      begin
-        RewardImporter.call(rewards)
-      rescue ActiveRecord::AssociationTypeMismatch
-        flash.now[:alert] = 'At least one reward was assigned to not existing category!'
-        render :import_form
-      rescue ActiveRecord::RecordNotSaved
-        flash.now[:alert] = 'There was problem with saving rewards!'
-        render :import_form
+      result = RewardImporter.call(rewards_file)
+      if result.success?
+        redirect_to admins_rewards_path, notice: "Successfuly imported #{result.value!(:count)}"
       else
-        rewards_file.close
-        redirect_to admins_rewards_path, notice: 'Rewards were successfuly imported.'
+        flash.now[:alert] = "Error occured during importing.
+                             #{result.failure[:error]} in row: #{result.failure[:row]}
+                            "
+        render :import_form
       end
     end
 

--- a/app/services/application_service.rb
+++ b/app/services/application_service.rb
@@ -1,9 +1,23 @@
 class ApplicationService
+  attr_reader :result
+
   def initialize
     raise 'Implement initilization'
   end
 
   def self.call(...)
     new(...).call
+  end
+
+  def success?
+    result[:success?]
+  end
+
+  def value!(value)
+    result[:value!][value]
+  end
+
+  def failure
+    result[:failure]
   end
 end

--- a/app/services/reward_importer.rb
+++ b/app/services/reward_importer.rb
@@ -2,20 +2,57 @@ class RewardImporter < ApplicationService
   attr_reader :rewards
 
   # rubocop:disable Lint/MissingSuper
-  def initialize(rewards)
+  def initialize(rewards_file)
+    @result = { success?: nil, failure: Hash.new(error: '', row: nil) }
+    rewards = array_of_reward_hashes(CSV.parse(rewards_file.read, col_sep: ','))
+    if rewards.pluck(:title).uniq.length != rewards.length
+      duplicate_titles = rewards.pluck(:title).group_by { |e| e }.select { |_, v| v.size > 1 }.keys
+      result[:success?] = false
+      result[:failure][:error] = "There is more than one entry per reward for rewards with titles:
+      \"#{duplicate_titles.join('", "')}\"!"
+      result[:failure][:row] = 0
+    end
+    rewards_file.close
     @rewards = rewards
   end
   # rubocop:enable Lint/MissingSuper
 
   def call
-    Reward.transaction do
-      rewards.each do |reward_values|
-        reward = Reward.find_or_initialize_by(title: reward_values[:title])
-        reward.price = reward_values[:price]
-        reward.description = reward_values[:description]
-        reward.categories = [Category.find_by(title: reward_values[:category])]
-        reward.save!
+    return self unless result[:success?].nil?
+
+    begin
+      Reward.transaction do
+        rewards.each_with_index do |reward_values, i|
+          reward = Reward.find_or_initialize_by(title: reward_values[:title])
+          reward.price = reward_values[:price]
+          reward.description = reward_values[:description]
+          category = Category.find_by(title: reward_values[:category])
+          unless category
+            result[:success?] = false
+            result[:failure][:error] = "Category with this title doesn't exit"
+            result[:failure][:row] = i
+            raise ActiveRecord::Rollback
+          end
+          reward.categories = [category]
+          reward.save!
+        end
+
+        result[:success?] = true
+        result[:value!] = Hash.new(count: rewards.length, imported_reward_titles: rewards.pluck(:title))
       end
+    rescue ActiveRecord::RecordNotSaved
+      result[:success?] = false
+      result[:failure][:error] = 'Unknown problem'
+      result[:failure][:row] = 0
     end
+    self
+  end
+
+  private
+
+  def array_of_reward_hashes(rewards_array)
+    rewards = rewards_array.map { |r| r.map!(&:strip) }
+    headers = rewards.shift.map(&:to_sym)
+    rewards.map! { |row| row.map.with_index { |v, i| [headers[i], v] }.to_h }
   end
 end

--- a/app/services/reward_importer.rb
+++ b/app/services/reward_importer.rb
@@ -38,7 +38,7 @@ class RewardImporter < ApplicationService
         end
 
         result[:success?] = true
-        result[:value!] = Hash.new(count: rewards.length, imported_reward_titles: rewards.pluck(:title))
+        result[:value!] = { count: rewards.length, imported_reward_titles: rewards.pluck(:title) }
       end
     rescue ActiveRecord::RecordNotSaved
       result[:success?] = false

--- a/spec/system/admins/reward_handling_spec.rb
+++ b/spec/system/admins/reward_handling_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe 'Rewards handling allows' do
       click_link 'Import Rewards'
       attach_file 'reward_file', reward_file_path.join('rewards_incorrect_category.csv')
       click_button 'Import Rewards'
-      expect(page).to have_content 'At least one reward was assigned to not existing category!'
+      expect(page).to have_content 'Category with this title doesn\'t exit in row: 0'
     end
 
     it '- fails one reward is updated multiple times in one import file' do
@@ -88,7 +88,7 @@ RSpec.describe 'Rewards handling allows' do
       click_link 'Import Rewards'
       attach_file 'reward_file', reward_file_path.join('rewards_not_unique_entries.csv')
       click_button 'Import Rewards'
-      expect(page).to have_content 'There is more than one entry per reward!'
+      expect(page).to have_content 'There is more than one entry per reward for rewards with titles: "reward_title1"'
     end
 
     it '- succedes when file is correct' do
@@ -98,7 +98,7 @@ RSpec.describe 'Rewards handling allows' do
       click_link 'Import Rewards'
       attach_file 'reward_file', reward_file_path.join('rewards_correct.csv')
       click_button 'Import Rewards'
-      expect(page).to have_content 'Rewards were successfuly imported.'
+      expect(page).to have_content 'Successfuly imported 2 rewards.'
       reward.reload
       expect(reward.categories[0]).to eq(import_category2)
       expect(page).to have_content 'reward_title2'


### PR DESCRIPTION
Use hash to pass result of importing rewards from service object

In this PR I changed the way I control flow of application to reduce expection handling and make passing information about result of service objects easier.
I also moved some logic that should have been in service object from controller to initialization of service object.